### PR TITLE
Add Docker Setup to Documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ jobs:
 
     - stage: deployment
       name: "Deploy GitHub Pages Documentation"
+      if: branch = master # run job only on master
       language: node_js
       node_js:
         - 12

--- a/docs/src/docs/usage/getting-started.mdx
+++ b/docs/src/docs/usage/getting-started.mdx
@@ -6,9 +6,29 @@ metaDescription: 'Getting Started'
 
 ## Introduction
 
-The documented setup here is used get a developer up and running quickly implement and deploy The Loch Sense Monster software stack onto a device.
+The documented setup here is used get a developer up and running quickly implement and deploy the Nightgown software stack onto a device. There are two setup methods to build and flash the ESP32 device which are listed below. The docker setup is the quickest method to setup the device if the user is fairly familiar with docker containers.
 
-## Dependency Setup
+1. [Docker Setup](#docker-setup)
+2. [Manual Setup](#manual-setup)
+
+Setting up the device in either methods requires performing the following steps:
+
+- Clone external library (used for interfacing with sensors)
+- Set target device (ESP32 or ESP32S2)
+- Configure device using `menuconfig`
+- Build, flash, and read device output (optional)
+
+---
+
+## Docker Setup
+
+The docker configuration has primarily been tested using a linux OS.
+
+---
+
+## Manual Setup
+
+### Dependency Setup
 
 Dependencies are required in order to compile and target the device.
 
@@ -42,7 +62,7 @@ source $IDF_PATH/exort.sh
 export IDF_LIB_PATH=$BUILD_ENV/esp-idf-lib
 ```
 
-## Set Target Device
+### Set Target Device
 
 Before configuration of the build, setting a device target must be done to indicate what chip is being targeted for the build. The primary two options are the `ESP32` and the `ESP32-S2` device. ESP8266 is not officially supported but will likely work as well.
 
@@ -58,7 +78,7 @@ For ESP32-S2 devices, run the following:
 idf.py set-target esp32s2
 ```
 
-## Configuration
+### Configuration
 
 Configuration parameters can be defined using the ESP-IDF configuration menu by executing the following commands and modify custom project configurations within the menu.
 
@@ -79,7 +99,7 @@ The `Monster Configuration` menu defines several parameters used for the softwar
 | DHT11 GPIO Pin       | GPIO pin to read the DHT11 sensor |
 | HTTP POST Endpoint   | HTTP endpoint to post data |
 
-## Build and Compile
+### Build and Compile
 
 Building and compiling the code will begin creating the required binaries for the build and store them in the `build/` folder.
 
@@ -89,7 +109,7 @@ To begin building the code run:
 idf.py build
 ```
 
-## Flash and Monitor
+### Flash and Monitor
 
 To flash the build, find the serial location of the device on the host machine (`/dev/ttyUSB0` in this case) and run the `flash` command. Use the `monitor` command to read the serial output of the device. The baudrate is defined in the menu options discussed prior.
 

--- a/docs/src/docs/usage/getting-started.mdx
+++ b/docs/src/docs/usage/getting-started.mdx
@@ -15,7 +15,7 @@ Setting up the device in either methods requires performing the following steps:
 
 - Clone external library (used for interfacing with sensors)
 - Set target device (ESP32 or ESP32S2)
-- Configure device using `menuconfig`
+- Configure device using `idf.py menuconfig` (configuration options described [here](#menu-configuration-options-idfpy-menuconfig))
 - Build, flash, and read device output (optional)
 
 ---
@@ -43,6 +43,47 @@ git clone https://github.com/UncleRus/esp-idf-lib.git
 git clone https://github.com/LilDataMonster/nightgown.git
 cd nightgown
 ```
+
+### Pull Build Tools
+
+Use the following command to pull the espressif build tools from DockerHub. Espressif documentation can be found [here](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-docker-image.html).
+
+```bash
+docker pull espressif/idf
+```
+
+### Running and Exposing the Container
+
+The container enables the use of a ready-made `idf.py` command but only within the docker container. Since the host does not have direct access to the container, specific pathways into the docker container will need to be exposed for it to be used. A short description of what each docker argument does is provided in the proceeding table. For more information about docker arguments and parameters, checkout the [Docker Reference Documentation](https://docs.docker.com/reference/).
+
+To expose the container to the host, a number of arguments are provided to docker:
+
+```bash
+docker run \
+        -it \
+        --rm \
+        --privileged \
+        --device /dev/ttyUSB0:/dev/ttyUSB0 \
+        -e LC_ALL=C.UTF-8 \
+        -e IDF_LIB_PATH=/esp-lib \
+        -v $WORKSPACE/esp-idf-lib:/esp-lib \
+        -v $WORKSPACE/nightgown:/project \
+        -w /project \
+        espressif/idf idf.py
+```
+
+| Docker Argument                 | Description                                                                                    |
+|---------------------------------|------------------------------------------------------------------------------------------------|
+| `-it`                           | Interactive mode, mainly for using with `menuconfig`                                           |
+| `--rm`                          | WiFi Password to connect to AP with                                                            |
+| `--privileged`                  | Run as root to avoid permission issues (not particularly needed if permissions setup properly) |
+| `--device <host>:<container>`   | Map the device from the host path to a path in the container                                   |
+| `-e Key=Value`                  | Defines environment variables within the container                                             |
+| `-v <host>:<container>`         | Maps a directory from the host to a path in the container                                      |
+| `-w <container path>`           | Set working directory of container's path                                                      |
+
+
+Once the environment is setup, the steps from [Flashing the Device](#flashing-the-device) can be performed.
 
 ---
 
@@ -86,19 +127,29 @@ git clone https://github.com/LilDataMonster/nightgown.git
 cd nightgown
 ```
 
-### Pull Build Tools
-
-Use the following command to pull the espressif build tools from DockerHub. Espressif documentation can be found [here](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-docker-image.html).
-
-```bash
-docker pull espressif/idf
-```
+Once the environment is setup, the steps from [Flashing the Device](#flashing-the-device) can be performed.
 
 ---
 
 # Flashing the Device
 
-Flashing the device can be done using the following steps. The setup is the same for both Docker and the manual setup.
+Flashing the device can be done using the following steps. The setup is the same for both Docker and the manual setup using the `idf.py` command. In the docker setup, the full `docker run` command must be used with all the appropriate arguments followed by `espressif/idf idf.py` and the corresponding commands below.
+
+For example, to run the commands detailed in [Flash and Monitor](#flash-and-monitor), use the following:
+
+```bash
+docker run \
+        -it \
+        --rm \
+        --privileged \
+        --device /dev/ttyUSB0:/dev/ttyUSB0 \
+        -e LC_ALL=C.UTF-8 \
+        -e IDF_LIB_PATH=/esp-lib \
+        -v $WORKSPACE/esp-idf-lib:/esp-lib \
+        -v $WORKSPACE/nightgown:/project \
+        -w /project \
+        espressif/idf idf.py flash monitor
+```
 
 ## Set Target Device
 

--- a/docs/src/docs/usage/getting-started.mdx
+++ b/docs/src/docs/usage/getting-started.mdx
@@ -22,7 +22,27 @@ Setting up the device in either methods requires performing the following steps:
 
 ## Docker Setup
 
-The docker configuration has primarily been tested using a linux OS.
+The docker configuration has primarily been tested using a linux OS. The main convenience of using docker is not having the need to install the expressif framework manually, instead the build tools are within a docker container which can be pulled from DockerHub and exposing the device to the container as necessary.
+
+### Dependency Setup
+
+The following dependencies are required in order to compile and target the device.
+
+- ESP-IDF-LIB
+  - https://esp-idf-lib.readthedocs.io/en/latest/
+
+```bash
+# define location to store dependencies
+export WORKSPACE=$HOME
+
+# clone dependencies
+cd $WORKSPACE
+git clone https://github.com/UncleRus/esp-idf-lib.git
+
+# clone the project
+git clone https://github.com/LilDataMonster/nightgown.git
+cd nightgown
+```
 
 ---
 
@@ -30,7 +50,7 @@ The docker configuration has primarily been tested using a linux OS.
 
 ### Dependency Setup
 
-Dependencies are required in order to compile and target the device.
+The following dependencies are required in order to compile and target the device.
 
 - ESP-IDF
   - https://docs.espressif.com/projects/esp-idf/en/latest/esp32/
@@ -38,31 +58,49 @@ Dependencies are required in order to compile and target the device.
 - ESP-IDF-LIB
   - https://esp-idf-lib.readthedocs.io/en/latest/
 
-To setup the development environment, the ESP-IDF environment variables must be set:
+To setup the development environment, the espressif build tools must be installed (see espressif's [Getting Started](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html) page). The ESP-IDF environment variables must be set:
 
-| Environment Variable | Description      |
-|----------------------|------------------|
-|`IDF_PATH`            | ESP-IDF path     |
-|`IDF_LIB_PATH`        | ESP-IDF-LIB path |
+| Environment Variable | Description                                   |
+|----------------------|-----------------------------------------------|
+|`IDF_PATH`            | ESP-IDF path for the espressif build tools    |
+|`IDF_LIB_PATH`        | ESP-IDF-LIB path of the external library      |
 
 ```bash
 # define location to store dependencies
-export BUILD_ENV=$HOME
+export WORKSPACE=$HOME
 
 # clone dependencies
-cd $BUILD_ENV
+cd $WORKSPACE
 git clone https://github.com/espressif/esp-idf.git
 git clone https://github.com/UncleRus/esp-idf-lib.git
 
 # setup environment variables
-export IDF_PATH=$BUILD_ENV/esp-idf
+export IDF_PATH=$WORKSPACE/esp-idf
 source $IDF_PATH/add_path.sh
 source $IDF_PATH/exort.sh
 
-export IDF_LIB_PATH=$BUILD_ENV/esp-idf-lib
+export IDF_LIB_PATH=$WORKSPACE/esp-idf-lib
+
+# clone the project
+git clone https://github.com/LilDataMonster/nightgown.git
+cd nightgown
 ```
 
-### Set Target Device
+### Pull Build Tools
+
+Use the following command to pull the espressif build tools from DockerHub. Espressif documentation can be found [here](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-docker-image.html).
+
+```bash
+docker pull espressif/idf
+```
+
+---
+
+# Flashing the Device
+
+Flashing the device can be done using the following steps. The setup is the same for both Docker and the manual setup.
+
+## Set Target Device
 
 Before configuration of the build, setting a device target must be done to indicate what chip is being targeted for the build. The primary two options are the `ESP32` and the `ESP32-S2` device. ESP8266 is not officially supported but will likely work as well.
 
@@ -78,13 +116,35 @@ For ESP32-S2 devices, run the following:
 idf.py set-target esp32s2
 ```
 
-### Configuration
+## Configuration
 
 Configuration parameters can be defined using the ESP-IDF configuration menu by executing the following commands and modify custom project configurations within the menu.
 
 ```bash
 idf.py menuconfig
 ```
+
+## Build and Compile
+
+Building and compiling the code will begin creating the required binaries for the build and store them in the `build/` folder.
+
+To begin building the code run:
+
+```bash
+idf.py build
+```
+
+## Flash and Monitor
+
+To flash the build, find the serial location of the device on the host machine (`/dev/ttyUSB0` in this case) and run the `flash` command. Use the `monitor` command to read the serial output of the device. The baudrate is defined in the menu options discussed prior.
+
+```bash
+idf.py -p /dev/ttyUSB0 flash monitor
+```
+
+---
+
+## Menu Configuration Options (`idf.py menuconfig`)
 
 The `Monster Configuration` menu defines several parameters used for the software stack.
 
@@ -99,20 +159,4 @@ The `Monster Configuration` menu defines several parameters used for the softwar
 | DHT11 GPIO Pin       | GPIO pin to read the DHT11 sensor |
 | HTTP POST Endpoint   | HTTP endpoint to post data |
 
-### Build and Compile
-
-Building and compiling the code will begin creating the required binaries for the build and store them in the `build/` folder.
-
-To begin building the code run:
-
-```bash
-idf.py build
-```
-
-### Flash and Monitor
-
-To flash the build, find the serial location of the device on the host machine (`/dev/ttyUSB0` in this case) and run the `flash` command. Use the `monitor` command to read the serial output of the device. The baudrate is defined in the menu options discussed prior.
-
-```bash
-idf.py -p /dev/ttyUSB0 flash monitor
-```
+---


### PR DESCRIPTION
- Adds docker setup in documentation
- TravisCI deploys documentation to gh-pages branch only when deployed to master

Closes #13 